### PR TITLE
Distinguishes that there is an analysis error or there is not found app.conf

### DIFF
--- a/context.go
+++ b/context.go
@@ -15,10 +15,10 @@
 package config
 
 import (
-	"path"
-	"strings"
-	"os"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 // Context structure handles the parsing of app.conf
@@ -38,12 +38,12 @@ func LoadContext(confName string, confPaths []string) (*Context, error) {
 	var err error
 	var conf *Config
 	for _, confPath := range confPaths {
-		filePath := path.Join(confPath, confName)
-		conf, err = ReadDefault(filePath)
+		path := filepath.Join(confPath, confName)
+		conf, err = ReadDefault(path)
 		if err == nil {
 			return &Context{config: conf}, nil
 		} else if _, isPathErr := err.(*os.PathError); !isPathErr {
-			return nil, errors.New(filePath + " " + err.Error())
+			return nil, errors.New(path + " " + err.Error())
 		}
 
 	}
@@ -140,8 +140,8 @@ func stripQuotes(s string) string {
 		return s
 	}
 
-	if s[0] == '"' && s[len(s) - 1] == '"' {
-		return s[1 : len(s) - 1]
+	if s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
 	}
 
 	return s

--- a/context.go
+++ b/context.go
@@ -17,6 +17,8 @@ package config
 import (
 	"path"
 	"strings"
+	"os"
+	"errors"
 )
 
 // Context structure handles the parsing of app.conf
@@ -36,10 +38,14 @@ func LoadContext(confName string, confPaths []string) (*Context, error) {
 	var err error
 	var conf *Config
 	for _, confPath := range confPaths {
-		conf, err = ReadDefault(path.Join(confPath, confName))
+		filePath := path.Join(confPath, confName)
+		conf, err = ReadDefault(filePath)
 		if err == nil {
 			return &Context{config: conf}, nil
+		} else if _, isPathErr := err.(*os.PathError); !isPathErr {
+			return nil, errors.New(filePath + " " + err.Error())
 		}
+
 	}
 	return nil, err
 }
@@ -134,8 +140,8 @@ func stripQuotes(s string) string {
 		return s
 	}
 
-	if s[0] == '"' && s[len(s)-1] == '"' {
-		return s[1 : len(s)-1]
+	if s[0] == '"' && s[len(s) - 1] == '"' {
+		return s[1 : len(s) - 1]
 	}
 
 	return s


### PR DESCRIPTION
（Sorry for my poor English.)

"revel run project " is said to always be "no such file or directory" when you run even if there is a problem on app.conf.

example
https://raw.githubusercontent.com/yuki2006/revel_helloworld/master/conf/app.conf

```
2016/06/04 00:10:16 revel.go:163: Failed to load app.conf: open gopath/to/github.com/revel/revel/conf/app.conf: no such file or directory
```


It has been changed to the following
```
2016/06/04 00:16:38 revel.go:163: Failed to load app.conf: open gopath/to/project/conf/app.conf could not parse line: INIError
```

